### PR TITLE
Add simulated test for non-zero spinel iid.

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test build expect
+        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' VIRTUAL_TIME=0 MULTIPAN_RCP=1 OT_NODE_TYPE=rcp ./script/test build expect
     - name: Run ot-fct
       run: |
         OT_CMAKE_NINJA_TARGET="ot-fct" script/cmake-build posix

--- a/examples/platforms/simulation/CMakeLists.txt
+++ b/examples/platforms/simulation/CMakeLists.txt
@@ -55,6 +55,7 @@ list(APPEND OT_PLATFORM_DEFINES
     "OPENTHREAD_EXAMPLES_SIMULATION=1"
     "OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1"
 )
+
 set(OT_PLATFORM_DEFINES ${OT_PLATFORM_DEFINES} PARENT_SCOPE)
 
 add_library(openthread-simulation
@@ -80,6 +81,14 @@ add_library(openthread-simulation
 find_library(LIBRT rt)
 if(LIBRT)
     target_link_libraries(openthread-simulation PRIVATE ${LIBRT})
+endif()
+
+# Enable OPENTHREAD_RADIO symbol for openthread-simulation library in case of NCP/RCP apps
+# as it is needed by radio.c
+if(OT_APP_NCP OR OT_APP_RCP)
+    if(OT_MULTIPAN_RCP)
+        target_compile_definitions(openthread-simulation PRIVATE "OPENTHREAD_RADIO=1")
+    endif()
 endif()
 
 target_link_libraries(openthread-simulation PRIVATE

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -160,6 +160,15 @@ otRadioCaps gRadioCaps =
     OT_RADIO_CAPS_NONE;
 #endif
 
+#if OPENTHREAD_RADIO && OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE == 1
+extern uint8_t otNcpPlatGetCurCommandIid(void);
+#else // OPENTHREAD_RADIO && OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE == 1
+#define otNcpPlatGetCurCommandIid() 0
+#endif // OPENTHREAD_RADIO && OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE == 1
+#define RADIO_BCAST_IID (0)
+#define RADIO_BCAST_PANID (0xFFFF)
+#define INVALID_VALUE (0xFF)
+
 static uint32_t         sMacFrameCounter;
 static uint8_t          sKeyId;
 static otMacKeyMaterial sPrevKey;
@@ -299,25 +308,49 @@ static void ReverseExtAddress(otExtAddress *aReversed, const otExtAddress *aOrig
     }
 }
 
+static inline uint8_t getIidFromFrame(const otRadioFrame *aFrame)
+{
+    uint8_t iid = 0;
+    OT_UNUSED_VARIABLE(aFrame);
+#if OPENTHREAD_RADIO && OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE == 1
+    otPanId destPanId;
+
+    destPanId = otMacGetDstPanId(aFrame);
+    if (destPanId == RADIO_BCAST_PANID)
+    {
+        iid = RADIO_BCAST_IID;
+    }
+    else
+    {
+        iid = utilsSoftSrcMatchFindIidFromPanId(destPanId);
+    }
+#endif
+
+    return iid;
+}
+
 static bool hasFramePending(const otRadioFrame *aFrame)
 {
     bool         rval = false;
     otMacAddress src;
+    uint8_t      iid;
 
     otEXPECT_ACTION(sSrcMatchEnabled, rval = true);
     otEXPECT(otMacFrameGetSrcAddr(aFrame, &src) == OT_ERROR_NONE);
+    iid = getIidFromFrame(aFrame);
+    assert(iid != INVALID_VALUE);
 
     switch (src.mType)
     {
     case OT_MAC_ADDRESS_TYPE_SHORT:
-        rval = utilsSoftSrcMatchShortFindEntry(0, src.mAddress.mShortAddress) >= 0;
+        rval = utilsSoftSrcMatchShortFindEntry(iid, src.mAddress.mShortAddress) >= 0;
         break;
     case OT_MAC_ADDRESS_TYPE_EXTENDED:
     {
         otExtAddress extAddr;
 
         ReverseExtAddress(&extAddr, &src.mAddress.mExtAddress);
-        rval = utilsSoftSrcMatchExtFindEntry(0, &extAddr) >= 0;
+        rval = utilsSoftSrcMatchExtFindEntry(iid, &extAddr) >= 0;
         break;
     }
     default:
@@ -376,8 +409,10 @@ void otPlatRadioSetPanId(otInstance *aInstance, otPanId aPanid)
 
     assert(aInstance != NULL);
 
+    uint8_t iid = otNcpPlatGetCurCommandIid();
+
     sPanid = aPanid;
-    utilsSoftSrcMatchSetPanId(0, aPanid);
+    utilsSoftSrcMatchSetPanId(iid, aPanid);
 }
 
 void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
@@ -1070,6 +1105,7 @@ void radioProcessFrame(otInstance *aInstance)
 {
     otError      error = OT_ERROR_NONE;
     otMacAddress macAddress;
+    uint8_t      iid;
     OT_UNUSED_VARIABLE(macAddress);
 
     sReceiveFrame.mInfo.mRxInfo.mRssi = -20;
@@ -1082,6 +1118,10 @@ void radioProcessFrame(otInstance *aInstance)
 
     otEXPECT_ACTION(otMacFrameDoesAddrMatch(&sReceiveFrame, sPanid, sShortAddress, &sExtAddress),
                     error = OT_ERROR_ABORT);
+
+    iid = getIidFromFrame(&sReceiveFrame);
+    assert(iid != INVALID_VALUE);
+    sReceiveFrame.mIid = iid;
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     otEXPECT_ACTION(otMacFrameGetSrcAddr(&sReceiveFrame, &macAddress) == OT_ERROR_NONE, error = OT_ERROR_PARSE);

--- a/examples/platforms/utils/CMakeLists.txt
+++ b/examples/platforms/utils/CMakeLists.txt
@@ -36,6 +36,14 @@ add_library(openthread-platform-utils OBJECT
     soft_source_match_table.c
 )
 
+# Enable OPENTHREAD_RADIO symbol for openthread-platform-utils library in case of NCP/RCP apps
+# as it is needed by soft_source_match_table.c
+if(OT_APP_NCP OR OT_APP_RCP)
+    if(OT_MULTIPAN_RCP)
+        target_compile_definitions(openthread-platform-utils PRIVATE "OPENTHREAD_RADIO=1")
+    endif()
+endif()
+
 target_compile_definitions(openthread-platform-utils PRIVATE
     $<TARGET_PROPERTY:ot-config,INTERFACE_COMPILE_DEFINITIONS>
 )

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -144,6 +144,19 @@ uint8_t otMacFrameGetSequence(const otRadioFrame *aFrame)
     return static_cast<const Mac::Frame *>(aFrame)->GetSequence();
 }
 
+otPanId otMacGetDstPanId(const otRadioFrame *aFrame)
+{
+    otPanId aPanId = 0xFFFF;
+
+    if (static_cast<const Mac::RxFrame *>(aFrame)->IsDstPanIdPresent())
+    {
+        SuccessOrExit(static_cast<const Mac::RxFrame *>(aFrame)->GetDstPanId(aPanId));
+    }
+
+exit:
+    return aPanId;
+}
+
 void otMacFrameProcessTransmitAesCcm(otRadioFrame *aFrame, const otExtAddress *aExtAddress)
 {
     static_cast<Mac::TxFrame *>(aFrame)->ProcessTransmitAesCcm(*static_cast<const Mac::ExtAddress *>(aExtAddress));

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -176,6 +176,17 @@ otError otMacFrameGetDstAddr(const otRadioFrame *aFrame, otMacAddress *aMacAddre
 uint8_t otMacFrameGetSequence(const otRadioFrame *aFrame);
 
 /**
+ * Get destination PAN ID.
+ *
+ * @param[in]   aFrame          A pointer to the frame.
+ *
+ * @retval  The destination PAN ID of the frame. Returns 0xFFFF if destination PAN ID
+ *          is not present.
+ *
+ */
+otPanId otMacGetDstPanId(const otRadioFrame *aFrame);
+
+/**
  * This function performs AES CCM on the frame which is going to be sent.
  *
  * @param[in]  aFrame       A pointer to the MAC frame buffer that is going to be sent.

--- a/script/test
+++ b/script/test
@@ -86,6 +86,9 @@ readonly FULL_LOGS
 TREL=${TREL:-0}
 readonly TREL
 
+MULTIPAN_RCP="${MULTIPAN_RCP:-0}"
+readonly MULTIPAN_RCP
+
 LOCAL_OTBR_DIR=${LOCAL_OTBR_DIR:-""}
 readonly LOCAL_OTBR_DIR
 
@@ -152,6 +155,13 @@ build_simulation()
         fi
 
     fi
+
+    if [[ ${MULTIPAN_RCP} == 1 ]] && [[ ${OT_NODE_TYPE} == rcp* ]]; then
+
+        options+=("-DOT_MULTIPAN_RCP=ON")
+
+        OT_CMAKE_NINJA_TARGET=ot-rcp OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-simulation-${version}/multipan" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
+    fi
 }
 
 build_posix()
@@ -187,6 +197,13 @@ build_posix()
         options+=("-DOT_BACKBONE_ROUTER=ON")
 
         OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-posix-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
+    fi
+
+    if [[ ${MULTIPAN_RCP} == 1 ]]; then
+
+        options+=("-DOT_MULTIPAN_RCP=ON")
+
+        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-posix-${version}/multipan" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
     fi
 }
 
@@ -472,6 +489,7 @@ ENVIRONMENTS:
     THREAD_VERSION  1.1 for Thread 1.1 stack, 1.3 for Thread 1.3 stack. The default is 1.3.
     INTER_OP        1 to build 1.1 together. Only works when THREAD_VERSION is 1.3. The default is 0.
     INTER_OP_BBR    1 to build bbr version together. Only works when THREAD_VERSION is 1.3. The default is 1.
+    MULTIPAN_RCP    1 to build multi iid spinel support.
 
 COMMANDS:
     clean           Clean built files to prepare for new build.
@@ -617,6 +635,9 @@ envsetup()
     export OT_SIMULATION_APPS="${OT_BUILDDIR}/openthread-simulation-${THREAD_VERSION}/examples/apps"
     export OT_POSIX_APPS="${OT_BUILDDIR}/openthread-posix-${THREAD_VERSION}/src/posix"
 
+    export OT_SIMULATION_MP_APPS="${OT_BUILDDIR}/openthread-simulation-${THREAD_VERSION}/multipan/examples/apps"
+    export OT_POSIX_MP_APPS="${OT_BUILDDIR}/openthread-posix-${THREAD_VERSION}/multipan/src/posix"
+
     if [[ ! ${VIRTUAL_TIME+x} ]]; then
         # All expect tests only works in real time mode.
         VIRTUAL_TIME=1
@@ -629,7 +650,7 @@ envsetup()
     fi
 
     readonly VIRTUAL_TIME
-    export OT_NODE_TYPE VIRTUAL_TIME
+    export OT_NODE_TYPE VIRTUAL_TIME MULTIPAN_RCP
 
     # CMake always works in verbose mode if VERBOSE exists in environments.
     if [[ ${VERBOSE} == 1 ]]; then

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -84,7 +84,15 @@ proc spawn_node {id {type ""} {radio_url ""}} {
         set gcov_prefix "ot-run/$argv0/ot-gcda.$id"
     }
 
-    switch -regexp ${type} {
+    switch -regex ${type} {
+        {rcp-mp} {
+            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $::env(OT_POSIX_MP_APPS)/ot-cli $radio_url
+            send "factoryreset\n"
+            wait_for "state" "disabled"
+            expect_line "Done"
+            send "routerselectionjitter 1\n"
+            expect_line "Done"
+        }
         {rcp|rcp-cli} {
             spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $::env(OT_POSIX_APPS)/ot-cli $radio_url
             send "factoryreset\n"

--- a/tests/scripts/expect/posix-rcp-non-zero-iid.exp
+++ b/tests/scripts/expect/posix-rcp-non-zero-iid.exp
@@ -1,0 +1,83 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This test uses posix ot-cli and ot-rcp app with non-zero spinel iid support.
+# There are three nodes in this test (leader, rx-on-when-idle and rx-off-when-idle )
+# and each node spawn with non-zero iid.
+# This test perform energy scan, form and join the Thread network followed by ping
+# operation from a leader to each of the node.
+
+source "tests/scripts/expect/_common.exp"
+source "tests/scripts/expect/_multinode.exp"
+
+set is_mp_enabled $::env(MULTIPAN_RCP)
+
+# Skip the test if MULTIPAN_RCP is not enabled.
+if {${is_mp_enabled} == 0} {
+  exit 77
+}
+
+# spawn ot-cli and ot-rcp with non-zero spinel iid(=1) and energy scan enabled.
+spawn_node 1 "rcp-mp" "spinel+hdlc+forkpty://$::env(OT_SIMULATION_MP_APPS)/ncp/ot-rcp?iid=1&forkpty-arg=1&forkpty-arg=-E&no-reset=1"
+
+# Perform energy scan on node_1.
+send "ifconfig up\n"
+expect_line "Done"
+send "scan energy 0\n"
+expect_line "Done"
+send "scan energy 100\n"
+expect_line "Done"
+sleep 2
+
+# spawn node with spinel iid set to 2.
+spawn_node 2  "rcp-mp" "spinel+hdlc+forkpty://$::env(OT_SIMULATION_MP_APPS)/ncp/ot-rcp?iid=2&forkpty-arg=2"
+
+# Form a Thread network on node_1 as a leader and join node_2
+# as rx-on-when-idle and ping node_2.
+setup_two_nodes "rn" false
+switch_node 2
+set addr_2 [get_ipaddr mleid]
+switch_node 1
+send "ping $addr_2\n"
+expect "16 bytes from $addr_2: icmp_seq=1"
+
+# spawn node with spinel iid set to 3.
+spawn_node 3 "rcp-mp" "spinel+hdlc+forkpty://$::env(OT_SIMULATION_MP_APPS)/ncp/ot-rcp?iid=3&forkpty-arg=3"
+
+# Join node_3 as rx-off-when-idle and ping node_3
+setup_node 3 "-" "child"
+switch_node 3
+set addr_3 [get_ipaddr mleid]
+send "pollperiod 1000\n"
+expect_line "Done"
+switch_node 1
+send "ping $addr_3\n"
+expect "16 bytes from $addr_3: icmp_seq=2"
+
+dispose_all


### PR DESCRIPTION
- Added support in simulated PAL (radio.c) to tag correct spinel iid for received packets.
- Modified script/test to build a target for non-zero spinel iid tests. 
- Update CMakeLists.txt for openthread-simulation and openthread-platform-utils libraries to build with - OPENTHREAD_RADIO symbol when OT_MULTIPAN_RCP is enabled. 
- Added 'expect' test (posix-rcp-non-zero-iid.exp) for non-zero spinel iid.

Expect test will run as a part of git posix workflow under 'expect-linux' job.