### PR TITLE
Add posix vendor support with lib dependencies

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -95,9 +95,6 @@ if(NOT OT_CONFIG)
     set(OT_CONFIG "openthread-core-posix-config.h" PARENT_SCOPE)
 endif()
 
-set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
-       CACHE STRING "vendor interface implementation")
-
 set(CMAKE_EXE_LINKER_FLAGS "-rdynamic ${CMAKE_EXE_LINKER_FLAGS}" PARENT_SCOPE)
 
 add_library(openthread-posix
@@ -128,8 +125,9 @@ add_library(openthread-posix
     udp.cpp
     utils.cpp
     virtual_time.cpp
-    ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE}
 )
+
+include(vendor.cmake)
 
 target_link_libraries(openthread-posix
     PUBLIC

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -63,8 +63,7 @@ const char *otSysGetRadioUrlHelpString(void)
     "    spi-small-packet=[n]          Specify the smallest packet we can receive in a single transaction.\n"  \
     "                                  (larger packets will require two transactions). Default value is 32.\n"
 
-#else
-
+#elif OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_UART
 #define OT_RADIO_URL_HELP_BUS                                                                        \
     "    forkpty-arg[=argument string]  Command line arguments for subprocess, can be repeated.\n"   \
     "    spinel+hdlc+uart://${PATH_TO_UART_DEVICE}?${Parameters} for real uart device\n"             \
@@ -75,6 +74,14 @@ const char *otSysGetRadioUrlHelpString(void)
     "    uart-baudrate[=baudrate]       Uart baud rate, default is 115200.\n"                        \
     "    uart-flow-control              Enable flow control, disabled by default.\n"                 \
     "    uart-reset                     Reset connection after hard resetting RCP(USB CDC ACM).\n"
+
+#elif OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_VENDOR
+
+#ifndef OT_VENDOR_RADIO_URL_HELP_BUS
+#define OT_VENDOR_RADIO_URL_HELP_BUS "\n"
+#endif // OT_VENDOR_RADIO_URL_HELP_BUS
+
+#define OT_RADIO_URL_HELP_BUS OT_VENDOR_RADIO_URL_HELP_BUS
 
 #endif // OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_SPI
 

--- a/src/posix/platform/vendor.cmake
+++ b/src/posix/platform/vendor.cmake
@@ -1,0 +1,56 @@
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
+       CACHE STRING "vendor interface implementation")
+
+if(OT_POSIX_CONFIG_RCP_BUS MATCHES "VENDOR")
+    add_library(rcp-vendor-intf ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE})
+
+    target_link_libraries(rcp-vendor-intf PUBLIC ot-posix-config)
+
+    target_include_directories(rcp-vendor-intf
+        PUBLIC
+	    ${CMAKE_CURRENT_SOURCE_DIR}
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_SOURCE_DIR}/src/core
+            ${PROJECT_SOURCE_DIR}/src/posix/platform/include
+    )
+
+    target_link_libraries(openthread-posix PUBLIC rcp-vendor-intf)
+
+    find_package(RcpVendorDeps)
+    if(RcpVendorDeps_FOUND)
+	    target_link_libraries(rcp-vendor-intf PUBLIC RcpVendorDeps::RcpVendorDeps)
+    else()
+        message(WARNING "Vendor RCP Bus specified but dependency package was not found... \n"
+                "Continuing build with ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE}")
+    endif()
+endif()


### PR DESCRIPTION
A vendor interface implementation for the posix library is currently supported through linking a specified c++ source file. However, this is unable to accomodate dependencies for external libraries or header files that this vendor implementation source file may need.

The posix vendor support is changed to allow a vendor to specify a cmake RcpVendorDeps module file to resolve missing dependencies for a provided vendor support source file.

Additionally, this commit adds the ability for a vendor to define a radio url help message when the vendor rcp bus is selected instead of defaulting to the UART help message.